### PR TITLE
Update COW Token Logo

### DIFF
--- a/tokens/swapr/mainnet.json
+++ b/tokens/swapr/mainnet.json
@@ -460,6 +460,6 @@
         "name": "COW Token",
         "decimals": 18,
         "symbol": "COW",
-        "logoURI": "ipfs://QmQbmjXdz2UyhgetRDGeu119MSJ8KZ88ybxeN86obnqdps"
+        "logoURI": "ipfs://Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo"
     }
 ]


### PR DESCRIPTION
This PR updates the COW token logo to be the latest version. The file is currently hosted at: https://gnosis.mypinata.cloud/ipfs/Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo